### PR TITLE
replaced obsolete Stamen.baselayer with folium basemap

### DIFF
--- a/06-final_project/project.ipynb
+++ b/06-final_project/project.ipynb
@@ -270,16 +270,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run in console the following command before run the rest of code:\n",
-    "# jupyter nbextension enable --py --sys-prefix ipyleaflet\n",
-    "\n",
-    "from ipyleaflet import Map, basemaps\n",
-    "\n",
-    "# Map centred on (60 degrees latitude et -2.2 degrees longitude)\n",
-    "# Latitude, longitude\n",
-    "map = Map(center = (60, -2.2), zoom = 2, min_zoom = 1, max_zoom = 20, \n",
-    "    basemap=basemaps.Stamen.Terrain)\n",
-    "map"
+    "import folium\n",
+    "m = folium.Map(location = [40.317715, -3.784103393554688], zoom_start= 10)\n",
+    "m"
    ]
   },
   {


### PR DESCRIPTION
It appears the Stamen.baselayer option has been made obsolete (https://github.com/jmp75/ipyleaflet-dashboard-tools/issues/1).  This was causing errors for students working on the pre-work. I recommend using the folium library to create the basemap. 