### PR TITLE
Update 02.1-Intro-to-Numpy.ipynb

### DIFF
--- a/02-numpy/02.1-Intro-to-Numpy.ipynb
+++ b/02-numpy/02.1-Intro-to-Numpy.ipynb
@@ -119,7 +119,7 @@
     "\n",
     "![Arrays of different dimensions](https://github.com/4GeeksAcademy/machine-learning-prework/blob/main/02-numpy/assets/3D.png?raw=true \"3D\")\n",
     "\n",
-    "An N-dimensional array can also be created using the `array` function of the library. For example, if we want to create a 2D array:"
+    "A N-dimensional array can also be created using the `array` function of the library. For example, if we want to create a 2D array:"
    ]
   },
   {


### PR DESCRIPTION
I made the change because I think it is grammatically correct to use the a instead an before N-dimensional.