### PR TITLE
Fix Identificando_error_ortografico_in_Pandas_introduction

### DIFF
--- a/03-pandas/03.1-Intro-To-Pandas.es.ipynb
+++ b/03-pandas/03.1-Intro-To-Pandas.es.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "En concreto, los puntos clave de esta librería son:\n",
     "\n",
-    "- **Estructuras de datos**: Esta librería proporciona dos estructuras para trabajar con datos. Estos son las `Series` que son arrays unidimensionales etiquetados, similares a un vector, lista o secuencia y que es capaz de contener cualquier tipo de datos, y los `DataFrames`, que es una estructura bidimensional etiquetada con columnas que pueden ser de diferentes tipos, similar a una hoja de cálculo o a una tabla SQL.\n",
+    "- **Estructuras de datos**: Esta librería proporciona dos estructuras para trabajar con datos. Estas son las `Series` que son arrays unidimensionales etiquetados, similares a un vector, lista o secuencia y que es capaz de contener cualquier tipo de datos, y los `DataFrames`, que son una estructura bidimensional etiquetada con columnas que pueden ser de diferentes tipos, similar a una hoja de cálculo o a una tabla SQL.\n",
     "- **Manipulación de datos**: Pandas permite llevar a cabo un exhaustivo análisis de datos a través de funciones que pueden aplicarse directamente sobre sus estructuras de datos. Estas operaciones incluyen control de datos faltantes, filtrado de datos, fusión, combinación y unión de datos de diferentes fuentes...\n",
     "- **Eficiencia**: Todas las operaciones y/o funciones que se apliquen sobre las estructuras de datos son vectorizadas para mejorar el rendimiento en comparación con los bucles tradicionales e iteradores de Python.\n",
     "\n",
@@ -354,7 +354,7 @@
    "id": "758e57bd",
    "metadata": {},
    "source": [
-    "De esta forma se proporciona un índice personalizado para las columnas (etiquetando las filas dentro de un diccionario) y para las filas (con el argumento `index` tal y como sucedía con las series).\n",
+    "De esta forma se proporciona un índice personalizado para las columnas (etiquetando las columnas dentro de un diccionario) y para las filas (con el argumento `index` tal y como sucedía con las series).\n",
     "\n",
     "En un DataFrame se puede acceder a sus elementos por índice o por posición. A continuación se muestran algunas operaciones que se pueden realizar utilizando el DataFrame anterior:"
    ]


### PR DESCRIPTION
Corregí : 
1.-"Estos son las Series" por "Estas son las Series" 2.-"los DataFrames, que es una estructura..." por " los DataFrame, que son una estructura" 3.-"...etiquetando las filas dentro de un diccionario..." El error: Es incorrecto. En Pandas, las claves de un diccionario definen las columnas (col A, col B), no las filas. Las filas se definen mediante el argumento index.